### PR TITLE
Add CLISP packers

### DIFF
--- a/CLISP_packers/clisp_byte_to_char.js
+++ b/CLISP_packers/clisp_byte_to_char.js
@@ -31,7 +31,7 @@ Packers["CLISP"]["code: fewest chars"].push({
         code += "#.";
         code += ' '.repeat(code.length * 2 % 3);
         code = new TextEncoder().encode(code).reverse();
-        for (let i = 0; i < len; i += 3) {
+        for (let i = 0; i < code.length; i += 3) {
             let s = 0, p = 99 * 100 * 101;
             // 99
             let q = 100 * 101;
@@ -70,7 +70,7 @@ Packers["CLISP"]["code: fewest chars"].push({
         code += "#.";
         code += ' '.repeat(code.length * 2 % 3);
         code = new TextEncoder().encode(code.toUpperCase()).reverse();
-        for (let i = 0; i < len; i += 3) {
+        for (let i = 0; i < code.length; i += 3) {
             let s = 0, p = 99 * 100 * 101;
             // 99
             let q = 100 * 101;

--- a/CLISP_packers/clisp_byte_to_char.js
+++ b/CLISP_packers/clisp_byte_to_char.js
@@ -13,6 +13,7 @@ Packers["CLISP"]["code: fewest chars"].push({
 /**** 3:1 *****/
 Packers["CLISP"]["code: fewest chars"].push({
     'name': "3:1",
+    'authors': "CLOStrophobic and kg583",
     'limitations': "Must contain only ASCII characters above code 31.",
     'validity_check': function(code) {
         code = new TextEncoder().encode(code);
@@ -21,15 +22,15 @@ Packers["CLISP"]["code: fewest chars"].push({
                 return false;
         return true;
     },
-	'tips': [
-		"Remove newlines in format strings using `~%`.",
+    'tips': [
+        "Remove newlines in format strings using `~%`.",
         "The top level must be a single form.",
     ],
     'packer': function(code) {
         let compressed = "";
-		code += "#.";
+        code += "#.";
         code += ' '.repeat(code.length * 2 % 3);
-		code = new TextEncoder().encode(code).reverse();
+        code = new TextEncoder().encode(code).reverse();
         for (let i = 0; i < len; i += 3) {
             let s = 0, p = 99 * 100 * 101;
             // 99
@@ -51,6 +52,7 @@ Packers["CLISP"]["code: fewest chars"].push({
 /**** 3:1 (uppercase) *****/
 Packers["CLISP"]["code: fewest chars"].push({
     'name': "3:1 (uppercase)",
+    'authors': "CLOStrophobic and kg583",
     'limitations': "Must contain only ASCII characters below code 123.",
     'validity_check': function(code) {
         code = new TextEncoder().encode(code);
@@ -59,15 +61,15 @@ Packers["CLISP"]["code: fewest chars"].push({
                 return false;
         return true;
     },
-	'tips': [
-		"Do not use if you have a string literal with necessarily lowercase content.",
+    'tips': [
+        "Do not use if you have a string literal with necessarily lowercase content.",
         "The top level must be a single form.",
     ],
     'packer': function(code) {
         let compressed = "";
-		code += "#.";
+        code += "#.";
         code += ' '.repeat(code.length * 2 % 3);
-		code = new TextEncoder().encode(code.toUpperCase()).reverse();
+        code = new TextEncoder().encode(code.toUpperCase()).reverse();
         for (let i = 0; i < len; i += 3) {
             let s = 0, p = 99 * 100 * 101;
             // 99

--- a/CLISP_packers/clisp_byte_to_char.js
+++ b/CLISP_packers/clisp_byte_to_char.js
@@ -32,16 +32,16 @@ Packers["CLISP"]["code: fewest chars"].push({
         code += ' '.repeat(code.length * 2 % 3);
         code = new TextEncoder().encode(code).reverse();
         for (let i = 0; i < code.length; i += 3) {
-            let s = 0, p = 99 * 100 * 101;
+            let s = 0, p = 97 * 98 * 99;
+            // 97
+            let q = 98 * 99;
+            s += q * (code[i] - 32) * 49;
+            // 98
+            q = 97 * 99;
+            s += q * (code[i + 1] - 32) * 97;
             // 99
-            let q = 100 * 101;
-            s += q * (code[i] - 32) * 50;
-            // 100
-            q = 99 * 101;
-            s += q * (code[i + 1] - 32) * 99;
-            // 101
-            q = 99 * 100;
-            s += q * (code[i + 2] - 32) * 51;
+            q = 97 * 98;
+            s += q * (code[i + 2] - 32) * 50;
             // code point reached
             compressed += String.fromCodePoint(s % p);
         }
@@ -71,16 +71,16 @@ Packers["CLISP"]["code: fewest chars"].push({
         code += ' '.repeat(code.length * 2 % 3);
         code = new TextEncoder().encode(code.toUpperCase()).reverse();
         for (let i = 0; i < code.length; i += 3) {
-            let s = 0, p = 99 * 100 * 101;
+            let s = 0, p = 97 * 98 * 99;
+            // 97
+            let q = 98 * 99;
+            s += q * (code[i] - 32) * 49;
+            // 98
+            q = 97 * 99;
+            s += q * (code[i + 1] - 32) * 97;
             // 99
-            let q = 100 * 101;
-            s += q * (code[i] - 32) * 50;
-            // 100
-            q = 99 * 101;
-            s += q * (code[i + 1] - 32) * 99;
-            // 101
-            q = 99 * 100;
-            s += q * (code[i + 2] - 32) * 51;
+            q = 97 * 98;
+            s += q * (code[i + 2] - 32) * 50;
             // code point reached
             compressed += String.fromCodePoint(s % p);
         }

--- a/CLISP_packers/clisp_byte_to_char.js
+++ b/CLISP_packers/clisp_byte_to_char.js
@@ -1,0 +1,87 @@
+Packers["CLISP"]["code: fewest chars"] = [];
+
+Packers["CLISP"]["code: fewest chars"].push({
+    'name': "no packer",
+    'validity_check': function(code) {
+        return true;
+    },
+    'packer': function(code) {
+        return code;
+    }
+});
+
+/**** 3:1 *****/
+Packers["CLISP"]["code: fewest chars"].push({
+    'name': "3:1",
+    'limitations': "Must contain only ASCII characters above code 31.",
+    'validity_check': function(code) {
+        code = new TextEncoder().encode(code);
+        for (const c of code) 
+            if (c < 32 || c > 127)
+                return false;
+        return true;
+    },
+	'tips': [
+		"Remove newlines in format strings using `~%`.",
+        "The top level must be a single form.",
+    ],
+    'packer': function(code) {
+        let compressed = "";
+		code += "#.";
+        code += ' '.repeat(code.length * 2 % 3);
+		code = new TextEncoder().encode(code).reverse();
+        for (let i = 0; i < len; i += 3) {
+            let s = 0, p = 99 * 100 * 101;
+            // 99
+            let q = 100 * 101;
+            s += q * (code[i] - 32) * 50;
+            // 100
+            q = 99 * 101;
+            s += q * (code[i + 1] - 32) * 99;
+            // 101
+            q = 99 * 100;
+            s += q * (code[i + 2] - 32) * 51;
+            // code point reached
+            compressed += String.fromCodePoint(s % p);
+        }
+        return `(read-from-string(map'string'int-char(doseq(c"${compressed}"/)(dotimes'3(push(+(mod(char-int c)(+ .'97))32)/)))))`;
+    }
+});
+
+/**** 3:1 (uppercase) *****/
+Packers["CLISP"]["code: fewest chars"].push({
+    'name': "3:1 (uppercase)",
+    'limitations': "Must contain only ASCII characters below code 123.",
+    'validity_check': function(code) {
+        code = new TextEncoder().encode(code);
+        for (const c of code) 
+            if (c > 122)
+                return false;
+        return true;
+    },
+	'tips': [
+		"Do not use if you have a string literal with necessarily lowercase content.",
+        "The top level must be a single form.",
+    ],
+    'packer': function(code) {
+        let compressed = "";
+		code += "#.";
+        code += ' '.repeat(code.length * 2 % 3);
+		code = new TextEncoder().encode(code.toUpperCase()).reverse();
+        for (let i = 0; i < len; i += 3) {
+            let s = 0, p = 99 * 100 * 101;
+            // 99
+            let q = 100 * 101;
+            s += q * (code[i] - 32) * 50;
+            // 100
+            q = 99 * 101;
+            s += q * (code[i + 1] - 32) * 99;
+            // 101
+            q = 99 * 100;
+            s += q * (code[i + 2] - 32) * 51;
+            // code point reached
+            compressed += String.fromCodePoint(s % p);
+        }
+        return `(read-from-string(map'string'int-char(doseq(c"${compressed}"/)(dotimes'3(push(mod(char-int c)(+ .'97))/)))))`;
+    }
+});

--- a/CLISP_packers/clisp_byte_to_char.js
+++ b/CLISP_packers/clisp_byte_to_char.js
@@ -28,7 +28,7 @@ Packers["CLISP"]["code: fewest chars"].push({
     ],
     'packer': function(code) {
         let compressed = "";
-        code += "#.";
+        code = "#." + code;
         code += ' '.repeat(code.length * 2 % 3);
         code = new TextEncoder().encode(code).reverse();
         for (let i = 0; i < code.length; i += 3) {
@@ -67,20 +67,20 @@ Packers["CLISP"]["code: fewest chars"].push({
     ],
     'packer': function(code) {
         let compressed = "";
-        code += "#.";
+        code = "#." + code;
         code += ' '.repeat(code.length * 2 % 3);
         code = new TextEncoder().encode(code.toUpperCase()).reverse();
         for (let i = 0; i < code.length; i += 3) {
             let s = 0, p = 97 * 98 * 99;
             // 97
             let q = 98 * 99;
-            s += q * (code[i] - 32) * 49;
+            s += q * code[i] * 49;
             // 98
             q = 97 * 99;
-            s += q * (code[i + 1] - 32) * 97;
+            s += q * code[i + 1] * 97;
             // 99
             q = 97 * 98;
-            s += q * (code[i + 2] - 32) * 50;
+            s += q * code[i + 2] * 50;
             // code point reached
             compressed += String.fromCodePoint(s % p);
         }


### PR DESCRIPTION
There *is* a 2:1 packer for CLISP, but it's always longer than 3:1.

Something about Lisp also leads to annoyingly frequent issues with surrogates in the compressed code, though this is a problem that can happen in any lang so I don't do anything extra to mitigate it (which would be, like, putting random spaces in places).