### PR TITLE
Fix Scheme packers

### DIFF
--- a/Scheme_packers/scheme_byte_to_char.js
+++ b/Scheme_packers/scheme_byte_to_char.js
@@ -47,7 +47,7 @@ Packers["Scheme"]["code: fewest chars"].push({
         let compressed = "";
         code = new TextEncoder().encode(code);
         code = [...code, ...Array(code.length * 2 % 3).fill(32)];
-        for (let i = 0; i < len; i += 3) {
+        for (let i = 0; i < code.length; i += 3) {
             let s = 0, p = 97 * 98 * 99;
             // 97
             let q = 98 * 99;
@@ -61,6 +61,6 @@ Packers["Scheme"]["code: fewest chars"].push({
             // code point reached
             compressed += String.fromCodePoint(s % p + 32);
         }
-        return `(eval(read(open-input-string(fold-left(lambda'}(format"~a~{~a~}".'(map(lambda(x)(integer->char(+(mod(char-}#\ )x)32)))'(97 98 99))))""(string->list"${compressed}")))))`;
+        return `(eval(read(open-input-string(fold-left(lambda\`}(format"~a~{~a~}".\`(map(lambda(x)(integer->char(+(mod(char-}#\\ )x)32)))'(97 98 99))))""(string->list"${compressed}")))))`;
     }
 });


### PR DESCRIPTION
The 3:1 was broken on account of not escaping things correctly inside the code string.

As for the 2:1, the issue appears to be ` (` appearing at a bad offset in the code and being decoded to `\x00`. I had never seen this before since golfed code is usually pretty scant on whitespace. I'm really not sure why this happens.

Leaving as a draft if you have any suggestions (maybe just add a tip?).